### PR TITLE
Add upload-release-asset GitHub Action to upload PDF to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request, release]
+on: 
+  push:
+  pull_request:
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   release:
-    types: [published]
+    types: [prereleased, published]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, release]
 
 jobs:
   build:
@@ -41,4 +41,14 @@ jobs:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         BRANCH: gh-pages
         FOLDER: deploy
+        
+    - name: Upload Release Asset
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: deploy/traversaro-phd-thesis.pdf
+          asset_name: traversaro-phd-thesis.pdf
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   release:
-    types: [prereleased, published]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,5 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: deploy/traversaro-phd-thesis.pdf
           asset_name: traversaro-phd-thesis.pdf
+          asset_content_type: application/pdf
         


### PR DESCRIPTION
Furthermore, also  add release to the event that trigger the GitHub Action build. 
 See https://github.com/actions/upload-release-asset/issues/34 for more details. 