### PR TITLE
Fix Eq 2.78 gravity term for mixed-acceleration dynamics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed 
 - Fix typo threat/treat in Section 3.3.1 (https://github.com/traversaro/phd-thesis/pull/13).
 - Fix several typos in some equations in Chapter 2 (https://github.com/traversaro/phd-thesis/pull/19).
+- Fix Eq 2.78 gravity term for mixed-acceleration dynamics (https://github.com/traversaro/phd-thesis/pull/20)
 
 ## [1.0.0] - 2017-04-05
 ### Added 

--- a/thesis/Chapter20RigidBody/chapter-rigidbody.tex
+++ b/thesis/Chapter20RigidBody/chapter-rigidbody.tex
@@ -1620,7 +1620,7 @@ The dynamics using mixed acceleration can be written as:
 \end{bmatrix}
 &=& \IEEEnonumber
 \\
-\ls_{B[A]}\bbM_B \begin{bmatrix} \ls^A R^T_B g \\ 0_{3 \times 1} \end{bmatrix} &+& \ls_{B[A]} \rmf^x .
+\ls_{B[A]}\bbM_B \begin{bmatrix} \ls^A g \\ 0_{3 \times 1} \end{bmatrix} &+& \ls_{B[A]} \rmf^x .
 \end{IEEEeqnarray}
 
 \subsection{Sensor}


### PR DESCRIPTION

![Screenshot from 2021-01-08 16-02-41](https://user-images.githubusercontent.com/6506093/104032288-3e950b00-51ce-11eb-8c72-77ea43631117.png)

There seems to be an unintended $R^T$ in front of $g$.

- [x] CHANGELOG needs to be updated