### PR TITLE
Fixing typos

### DIFF
--- a/thesis/Chapter20RigidBody/chapter-rigidbody.tex
+++ b/thesis/Chapter20RigidBody/chapter-rigidbody.tex
@@ -1592,7 +1592,7 @@ Applying the accelerations and velocity transforms presented in Table~\ref{tab:v
 Using the notation introduced in this thesis in extended form, \eqref{eq:NewtonEulerInLeftTrivializedWithoutNotation} can be written as:
 \begin{IEEEeqnarray}{rCl}
 \label{eq:NewtonEulerInLeftTrivialized}
-\ls_B \bbM_B \ls^B \dot{\rmv}_{A,B} + \ls^B \rmv_{A,B} \bar{\times}^*\ls_B \bbM_B \ls^B {\rmv}
+\ls_B \bbM_B \ls^B \dot{\rmv}_{A,B} + \ls^B \rmv_{A,B} \bar{\times}^*\ls_B \bbM_B \ls^B {\rmv}_{A,B}
  &=&  \ls_B \bbM_B \begin{bmatrix} \ls^A R^T_B \ls^Ag \\ 0_{3 \times 1} \end{bmatrix} + \ls_B \rmf^x 
 \end{IEEEeqnarray}
 
@@ -1602,7 +1602,7 @@ Using the notation introduced in this thesis in extended form, \eqref{eq:NewtonE
 \ls_A \bbM_B \ls^A \dot{\rmv}_{A,B} + \ls^A \rmv_{A,B} \bar{\times}^*\ls_A \bbM_B \ls^A {\rmv}
 &=&  \ls_A \bbM_B \begin{bmatrix} \ls^Ag \\ 0_{3 \times 1} \end{bmatrix} + \ls_A \rmf^x .
 \end{IEEEeqnarray}
-While this equation may seem similar to \eqref{eq:NewtonEulerInLeftTrivialized} the main difference is that $\ls_B \bbM_B$ is a fixed quantity while $\ls_A \bbM_B =  \ls_A X^B \bbM_B \ls^B X_A$ that is a time-varying quantity that depends on the position of the rigid body. 
+While this equation may seem similar to \eqref{eq:NewtonEulerInLeftTrivialized} the main difference is that $\ls_B \bbM_B$ is a fixed quantity while $\ls_A \bbM_B =  \ls_A X^B \ls_B \bbM_B \ls^B X_A$ that is a time-varying quantity that depends on the position of the rigid body. 
 
 \subsection{Mixed}
 The dynamics using mixed acceleration can be written as:

--- a/thesis/Chapter30MultiBody/chapter-multibody.tex
+++ b/thesis/Chapter30MultiBody/chapter-multibody.tex
@@ -726,7 +726,7 @@ the first six rows of the mass matrix define the jacobian of the articulated bod
 \end{theorem}
 
 \begin{remark}
-In the following we indicate with $m_L$, $\ls^L c_L$ and $\ls^L \bbM_L$ the \emph{constant} inertial quantities for a specific link $L$. We indicate instead with $m$, $\ls^B c(s)$ and $\ls^L \bbM(s)$ without any subscript the inertial quantities for all the robot. Even if by analogy we use the same symbols we used in describing the dynamics of a single rigid body, always remember that for a multibody this quantities (except for the total mass) are shape-dependent.   
+In the following we indicate with $m_L$, $\ls^L c_L$ and $\ls_L \bbM_L$ the \emph{constant} inertial quantities for a specific link $L$. We indicate instead with $m$, $\ls^B c(s)$ and $\ls_L \bbM(s)$ without any subscript the inertial quantities for all the robot. Even if by analogy we use the same symbols we used in describing the dynamics of a single rigid body, always remember that for a multibody this quantities (except for the total mass) are shape-dependent.   
 \end{remark}
 
 


### PR DESCRIPTION
Fixing some typos:
- equation 2.76: right subscript missing for the velocity
- below equation 2.77: missing left subscript on the mass matrix on the right side of the equation.
- remark 3.7: on the mass matrices an superscript was used instead of subscript